### PR TITLE
Remove unnecessary print messages

### DIFF
--- a/botok/tries/trie.py
+++ b/botok/tries/trie.py
@@ -40,8 +40,6 @@ class Trie(BasicTrie):
         self.tmp_inflected = dict()
 
     def _load_trie(self):
-        print("Loading Trie...", end=" ", flush=True)
-        start = time.time()
         with self.pickled_file.open("rb") as f:
             self.head = pickle.load(f)
             version = self.head.data["_"]["version"]
@@ -50,8 +48,6 @@ class Trie(BasicTrie):
                     f"\nThe trie was build for botok {version}. Current version: {__version__}"
                 )
                 self._build_trie()
-        end = time.time()
-        print("({:.0f}s.)".format(end - start), flush=True)
 
     def _build_trie(self):
         """


### PR DESCRIPTION
Right now there is the message "Loading trie..." printed. This does not make much sense as it is always within a few seconds. Mostly Botok is intended for programmatic workflows, so we should optimize dx toward that. 

Closes #93 