### PR TITLE
CI FIX : removed `pkg_resources`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,6 @@ import re
 from pathlib import Path
 
 import setuptools
-from pkg_resources import parse_version
-
-assert parse_version(setuptools.__version__) >= parse_version("38.6.0")
-
 
 def get_version(prop, project):
     project = Path(__file__).parent / project / "vars.py"


### PR DESCRIPTION

fixes  #119 

### Problem
setuptools 82+ removed `pkg_resources`https://github.com/pypa/setuptools/issues/5174, which broke our CI. Our setup.py imported it to assert `setuptools >= 38.6.0.` 
### Solution:
Removed the assertion. It was a safeguard from 2017 when `long_description_content_type` was new. 
Today, setuptools is in the 80+ range and pip itself requires a much newer version so The check would never fail in practice. current code was kind of deadcode

reopen #120